### PR TITLE
feat: Add schema to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/bennett-sh/schemas/main/hm/smf-mod.v2.schema.json",
 	"version": "0.1.0",
 	"id": "YourPreferredAlias.AnIDForTheMod",
 	"name": "Incredible Mod",


### PR DESCRIPTION
I've created a JSON schema for the mod manifest enabling auto-completion and validation/errors creating a more friction-less dev experience. If you want, you can also download the schema file, add it to the SMF repo and use that instead of relying on me as a 3rd party.